### PR TITLE
Fix swapped channel metadata in subsampled (-H) ISO gain map export

### DIFF
--- a/toGainMapHDR/main.swift
+++ b/toGainMapHDR/main.swift
@@ -462,7 +462,7 @@ if !apple_gain_map && subsampling_bool {
                 )
             }
         }
-        xmlString = defaultHDRMetadata(GainMapMax: log2(pic_headroom),GainMapMin: 0.0, RGBType: 1)
+        xmlString = defaultHDRMetadata(GainMapMax: log2(pic_headroom),GainMapMin: 0.0, RGBType: 2)
     } else {
         gain_map_data_rgb.withUnsafeMutableBytes {
             if let baseAddress = $0.baseAddress {
@@ -476,7 +476,7 @@ if !apple_gain_map && subsampling_bool {
                 )
             }
         }
-        xmlString = defaultHDRMetadata(GainMapMax: log2(pic_headroom),GainMapMin: 0.0, RGBType: 2)
+        xmlString = defaultHDRMetadata(GainMapMax: log2(pic_headroom),GainMapMin: 0.0, RGBType: 1)
     }
     
     let xmlData = xmlString.data(using: .utf8)


### PR DESCRIPTION
## Problem

In the subsampled ISO gain map path (`-H`, the ImageIO branch in `main.swift`), the XMP channel-count metadata is attached the wrong way around relative to the rendered gain map data:

| Export | Gain map data rendered | XMP template attached |
|--------|------------------------|-----------------------|
| `-m` (monochrome) | `CIFormat.L8` — **1 channel** | `defaultHDRMetadata(... RGBType: 1)` → 3-channel (RGB) `HDRToneMap` template |
| default (RGB) | `CIFormat.ARGB8` — **3 channels** | `defaultHDRMetadata(... RGBType: 2)` → 1-channel (mono) template |

In `Metadata.swift`, `RGBType: 1` is the 3-channel template (three `rdf:li` entries under `ChannelMetadata`) and `RGBType: 2` is the 1-channel one. So the mono output declares 3 channels and the RGB output declares 1 channel.

The auxiliary image data and its `DataDescription`/`PixelFormat` are correct for each branch — only the XMP is swapped. Readers that trust the declared channel count interpret the two outputs swapped: verified with Adobe's Gain Map Demo app, where `-m` files appear as RGB gain maps and default files appear as monochrome.

## Fix

Swap the `RGBType` arguments so the XMP matches the rendered pixel data: the mono (L8) branch now uses the 1-channel template and the RGB (ARGB) branch the 3-channel template.

Two-line change in `main.swift`; the default (non-`-H`) and `-g` paths are untouched.